### PR TITLE
Make install robust on environments without sudo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Local overrides (not versioned)
 gitconfig-work
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ The file is listed in `.gitignore` so it is never committed. Edit it with your w
 If you still have a **plain file** at `~/.gitconfig-work` from an older setup, `./install` moves it
 once into `gitconfig-work` in the repo, then replaces the home path with the symlink.
 
+The install **never cleans `$HOME`**: files not listed above are left untouched. If you want dotbot's
+`clean` behaviour (delete unmanaged files/symlinks from `$HOME`), add a `- clean: ['~']` task to
+`install.conf.yaml` — note that it deletes every loose file it does not manage
+(e.g. `~/.bash_aliases`, `~/.inputrc`, `~/.gitignore_global`).
+
 ## What gets linked
 
 | File in `$HOME` | Source |
@@ -32,10 +37,16 @@ once into `gitconfig-work` in the repo, then replaces the home path with the sym
 
 | File in `$HOME` | Source | Notes |
 | ----- | ------ | ------ |
-| Work git include | `scripts/ensure-gitconfig-work.sh` | Repo file `gitconfig-work` (gitignored); migrates old plain `~/.gitconfig-work` |
-| Oh My Zsh stack | `scripts/ensure-oh-my-zsh-and-plugins.sh` | Idempotent; see **Re-run install** |
-| WSL Hello sudo | `scripts/install-wsl-hello-sudo.sh` | WSL only; see **Re-run install** |
+| Work git include | `install-extras.sh` → `ensure-gitconfig-work.sh` | Repo file `gitconfig-work` (gitignored); migrates old plain `~/.gitconfig-work` |
+| Oh My Zsh stack | `install-extras.sh` → `ensure-oh-my-zsh-and-plugins.sh` | Idempotent; skipped if already present |
+| WSL Hello sudo | `install-extras.sh` → `install-wsl-hello-sudo.sh` | No-op outside WSL |
 | SSH git signing | `scripts/bootstrap-git-ssh-signing.sh` | Runs on `./install`; see below |
+
+`scripts/install-extras.sh` runs first as a single **non-fatal** task: every section is guarded, so a
+missing `sudo`/`apt-get`, missing network or an already-installed tool never aborts the install — the
+symlinks and SSH signing always run. On machines without sudo (containers, restricted users) system
+packages and `chsh` are skipped with a warning; fnm, opencode and gh are installed as static binaries
+under `~/.local/share/fnm`, `~/.opencode/bin` and `~/.local/bin` (all on `PATH` via `env.sh`).
 
 ## SSH key and `allowed_signers`
 
@@ -90,10 +101,11 @@ mkdir -p ~/work
 
 ## Re-run install
 
-`./install` is safe to re-run: dotbot updates symlinks and re-runs shell tasks.
-The work git file `gitconfig-work` in your clone is **not** overwritten if it exists; adjust the symlink
-when you change clone path.
-Some tasks (oh-my-zsh, fnm, etc.) may fail if already installed — that is expected.
+`./install` is safe to re-run: dotbot updates symlinks, re-runs the extras script (idempotent —
+already-installed tools are skipped) and refreshes `allowed_signers`. The work git file `gitconfig-work`
+in your clone is **not** overwritten if it exists; adjust the symlink when you change clone path.
+No section can abort the install: without sudo, system packages and `chsh` are skipped with a warning
+and everything else still runs.
 
 The Oh My Zsh step runs `scripts/ensure-oh-my-zsh-and-plugins.sh` (idempotent: skips install if
 `~/.oh-my-zsh` exists, clones themes/plugins only when missing).

--- a/bin/git-editor
+++ b/bin/git-editor
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env bash
 if command -v cursor >/dev/null 2>&1; then
   exec cursor --wait "$@"
 elif command -v code >/dev/null 2>&1; then

--- a/env.sh
+++ b/env.sh
@@ -1,4 +1,11 @@
 # Shared environment for all shells.
 export PATH="$HOME/.local/bin:$PATH"
+
+# opencode CLI — installed to ~/.opencode/bin by install-extras.sh.
+# Guarded so the PATH stays clean on machines where it is not installed.
+if [ -d "$HOME/.opencode/bin" ]; then
+    PATH="$HOME/.opencode/bin:$PATH"
+fi
+
 export PATH="$PATH:/snap/bin"
 export AWS_VAULT_BACKEND=file

--- a/gitconfig
+++ b/gitconfig
@@ -8,7 +8,7 @@
 	email = contact@raullazaro.com
 	signingkey = ~/.ssh/id_ed25519.pub
 [core]
-	editor = $HOME/dotfiles/bin/git-editor
+	editor = ~/dotfiles/bin/git-editor
 	autocrlf = input
 [gpg]
 	format = ssh

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -3,21 +3,7 @@
         force: true
 
 - shell:
-    - [sudo apt-get update -qq, apt update]
-    - [sudo apt-get install -y zsh openssh-client curl wget, "zsh, openssh-client, curl, wget"]
-    - [sudo apt-get install -y git-core, Install git-core]
-    - [curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash]
-    - [sudo apt-get install -y git-lfs]
-    - [git lfs install, Install git lfs]
-    - [bash scripts/ensure-oh-my-zsh-and-plugins.sh, Oh My Zsh + Powerlevel10k + plugins (idempotent)]
-    - [sudo chsh -s $(which zsh) $(whoami)]
-    - [curl -fsSL https://fnm.vercel.app/install | bash -s -- --skip-shell, Install fnm]
-    - [curl -fsSL https://opencode.ai/install | bash, Install opencode]
-    - [sudo apt-get install -y gh, Install GitHub CLI]
-    - [bash scripts/install-wsl-hello-sudo.sh, WSL Hello sudo (WSL only, idempotent)]
-    - [bash scripts/ensure-gitconfig-work.sh, gitconfig-work in repo + migrate old ~/.gitconfig-work if plain file]
-
-- clean: ['~']
+    - [bash scripts/install-extras.sh, "Optional extras (gitconfig-work, omz, wsl-hello, system pkgs, fnm, opencode, gh) - non-fatal"]
 
 - link:
     ~/.bashrc: bashrc
@@ -29,4 +15,4 @@
     ~/.p10k.zsh: p10k.zsh
 
 - shell:
-    - [bash scripts/bootstrap-git-ssh-signing.sh, SSH key for git + allowed_signers (personal + work email)]
+    - [bash scripts/bootstrap-git-ssh-signing.sh, "SSH key for git + allowed_signers (personal + work email)"]

--- a/scripts/install-extras.sh
+++ b/scripts/install-extras.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Optional install extras, run by dotbot as a single non-fatal shell task.
+# Every section is guarded so a missing privilege, package manager, network
+# or already-installed tool never aborts the install: dotbot skips the rest
+# of the shell block after the first failing command, so a failed `sudo apt`
+# used to take down oh-my-zsh, fnm, gitconfig-work and SSH signing with it.
+# This script always exits 0; problems are reported as warnings.
+
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+log()  { printf '[extras] %s\n' "$*"; }
+warn() { printf '[extras] WARNING: %s\n' "$*" >&2; }
+skip() { log "SKIP: $*"; }
+has()  { command -v "$1" >/dev/null 2>&1; }
+
+apt_install() { # $@ = packages
+  if ! has sudo || ! has apt-get; then
+    skip "apt packages ($*): no sudo/apt-get available"
+    return 0
+  fi
+  if sudo apt-get install -y "$@" >/dev/null 2>&1; then
+    log "apt: installed $*"
+  else
+    warn "apt: could not install $* (continuing)"
+  fi
+}
+
+# --- gitconfig-work ----------------------------------------------------------
+# Must run before dotbot links ~/.gitconfig-work (the repo file is gitignored
+# and created here if missing).
+if bash "${ROOT}/scripts/ensure-gitconfig-work.sh"; then
+  log "gitconfig-work: ensured"
+else
+  warn "gitconfig-work: could not be ensured (continuing)"
+fi
+
+# --- Oh My Zsh + Powerlevel10k + plugins ------------------------------------
+if bash "${ROOT}/scripts/ensure-oh-my-zsh-and-plugins.sh"; then
+  log "oh-my-zsh: ensured"
+else
+  warn "oh-my-zsh: could not be ensured (continuing)"
+fi
+
+# --- WSL Hello sudo (no-op outside WSL) --------------------------------------
+if bash "${ROOT}/scripts/install-wsl-hello-sudo.sh"; then
+  log "wsl-hello-sudo: ok"
+else
+  warn "wsl-hello-sudo: failed (continuing)"
+fi
+
+# --- System packages (best effort, needs sudo) --------------------------------
+if ! has sudo || ! has apt-get; then
+  skip "system packages: no sudo/apt-get available"
+else
+  sudo apt-get update -qq >/dev/null 2>&1 \
+    && log "apt: updated" \
+    || warn "apt: update failed (continuing)"
+  apt_install zsh openssh-client curl wget
+  apt_install git-core
+  apt_install git-lfs
+  if has zsh && has sudo; then
+    if sudo chsh -s "$(command -v zsh)" "$(id -un)" >/dev/null 2>&1; then
+      log "chsh: default shell set to zsh"
+    else
+      warn "chsh: could not change default shell (continuing)"
+    fi
+  else
+    skip "chsh: zsh not available"
+  fi
+fi
+
+if has git-lfs; then
+  git lfs install >/dev/null 2>&1 \
+    && log "git-lfs: hooks installed" \
+    || warn "git-lfs: hooks could not be installed (continuing)"
+else
+  skip "git-lfs: binary not available"
+fi
+
+# --- fnm ----------------------------------------------------------------------
+if has fnm; then
+  skip "fnm: already installed"
+else
+  if curl -fsSL https://fnm.vercel.app/install | bash -s -- --skip-shell; then
+    log "fnm: installed"
+  else
+    warn "fnm: install failed (continuing)"
+  fi
+fi
+
+# --- opencode -----------------------------------------------------------------
+if [ -x "$HOME/.opencode/bin/opencode" ]; then
+  skip "opencode: already installed"
+else
+  if curl -fsSL https://opencode.ai/install | bash; then
+    log "opencode: installed"
+  else
+    warn "opencode: install failed (continuing)"
+  fi
+fi
+
+# --- GitHub CLI ---------------------------------------------------------------
+# Static binary from the official releases (the Debian/Ubuntu apt package is
+# either missing or years behind), falling back to apt when downloads fail.
+if has gh; then
+  skip "gh: already installed"
+else
+  _arch="$(uname -m)"
+  case "$_arch" in
+    x86_64)      _gh_arch="amd64" ;;
+    aarch64|arm64) _gh_arch="arm64" ;;
+    *)           _gh_arch="" ;;
+  esac
+  _gh_ok=1
+  if [ -n "$_gh_arch" ]; then
+    _gh_ver="$(curl -fsSI https://github.com/cli/cli/releases/latest \
+      | grep -oP 'tag/\K[^[:space:]]+' | tr -d '\r' | sed 's/^v//')"
+    if [ -n "$_gh_ver" ] \
+      && curl -fsSL "https://github.com/cli/cli/releases/download/v${_gh_ver}/gh_${_gh_ver}_linux_${_gh_arch}.tar.gz" \
+           -o /tmp/gh.tar.gz; then
+      tar xzf /tmp/gh.tar.gz -C /tmp
+      mkdir -p "$HOME/.local/bin"
+      install -m 755 "/tmp/gh_${_gh_ver}_linux_${_gh_arch}/bin/gh" "$HOME/.local/bin/gh"
+      rm -rf /tmp/gh.tar.gz "/tmp/gh_${_gh_ver}_linux_${_gh_arch}"
+      log "gh: installed ${_gh_ver} (static binary)"
+      _gh_ok=0
+    fi
+  fi
+  if [ "$_gh_ok" -eq 1 ]; then
+    apt_install gh
+  fi
+fi

--- a/zshrc
+++ b/zshrc
@@ -130,7 +130,3 @@ alias prm='gh pr merge'
 if [ $TILIX_ID ] || [ $VTE_VERSION ]; then
         source /etc/profile.d/vte.sh
 fi
-
-
-# opencode
-export PATH=/home/raul/.opencode/bin:$PATH


### PR DESCRIPTION
## What

Reestructura la instalación para que sea **no-fatal** y funcione en entornos sin sudo (contenedores, CI, usuarios restringidos), donde antes un solo paso `sudo apt` fallido abortaba el resto del bloque shell (oh-my-zsh, fnm, opencode, gh, gitconfig-work y la firma SSH quedaban sin ejecutar y el install devolvía exit 1).

### Cambios

- **`install.conf.yaml`**: los 14 shell steps encadenados se sustituyen por un único paso `scripts/install-extras.sh` (no-fatal, siempre exit 0). Se elimina `clean: ['~']` (destructivo en máquinas existentes; documentado cómo optar de nuevo).
- **`scripts/install-extras.sh` (nuevo)**: guardas por tramo — apt/chsh solo si hay sudo+apt; fnm/opencode/gh se saltan si ya están; gh se instala como binario estático (el paquete apt de Debian está 50 versiones atrás y falta en Debian 12); `gitconfig-work` se asegura antes del link.
- **`env.sh`**: añade `~/.opencode/bin` al PATH (guarded) para todos los shells.
- **`zshrc`**: eliminado `export PATH=/home/raul/.opencode/bin` (ruta hardcodeada del autor, solo aplicaba a zsh).
- **`bin/git-editor`**: shebang `zsh` → `bash` (el fallback a $EDITOR era inalcanzable sin zsh).
- **`gitconfig`**: `core.editor` con `~` en vez de `$HOME`.
- **`README.md`**: documenta el install sin sudo, el no-clean y el re-run fiable (refresca `allowed_signers` siempre).
- **`.gitignore`**: ignora `.worktrees/`.

## Verificado (entorno real sin sudo, Debian 13 arm64)

- `bash scripts/install-extras.sh` → SKIP apt/chsh sin sudo, git-lfs hooks OK, fnm/opencode/gh ya instalados saltados, **exit 0**.
- `./install` completo con $HOME temporal → 7 symlinks creados, `bootstrap-git-ssh-signing.sh` ejecutado (clave + allowed_signers), **exit 0**.
- Los 5 commits llevan firma SSH verificada.